### PR TITLE
Notification & Profile menue gos under leafletmap

### DIFF
--- a/src/app/core/toolbar-notification/toolbar-notification.component.scss
+++ b/src/app/core/toolbar-notification/toolbar-notification.component.scss
@@ -34,7 +34,7 @@ $prefix: 'toolbar-notification';
 	top: 42px;
 	right: 28px;
 	min-width: 350px;
-	z-index: 2;
+	z-index: 1000;
 	transform: translateY(0) scale(0);
 	transform-origin: top right;
 	visibility: hidden;
@@ -53,7 +53,7 @@ $prefix: 'toolbar-notification';
 	    visibility: visible;
 	}
 	.card {
-
+      
 	    .header {
 	      background: #EEEEEE;
 	      min-height: 54px;


### PR DESCRIPTION
Notification & Profile div is rendering behind the leafletmap component they both contains the same .dropdown class as parent that will fix the issue